### PR TITLE
fix #8: enable featured image

### DIFF
--- a/src/controllers/image.controllers.js
+++ b/src/controllers/image.controllers.js
@@ -198,7 +198,7 @@ imageControllers.getPropertyImages = asyncWrapper(async (req, res, next) => {
 imageControllers.createPropertyImage = asyncWrapper(async (req, res, next) => {
   const {
     file,
-    body: { propertyId },
+    body: { propertyId, isFeatured },
   } = req;
 
   const imageFile = file;
@@ -212,7 +212,8 @@ imageControllers.createPropertyImage = asyncWrapper(async (req, res, next) => {
     ownerId,
     ownerModel,
     bucketDir,
-    isTemp
+    isTemp,
+    isFeatured
   );
 
   res
@@ -296,7 +297,7 @@ imageControllers.getBlogPostImage = asyncWrapper(async (req, res, next) => {
 imageControllers.createBlogPostImage = asyncWrapper(async (req, res, next) => {
   const {
     file,
-    body: { blogPostId },
+    body: { blogPostId, isFeatured },
   } = req;
   const imageFile = file;
   const ownerId = blogPostId;
@@ -309,7 +310,8 @@ imageControllers.createBlogPostImage = asyncWrapper(async (req, res, next) => {
     ownerId,
     ownerModel,
     bucketDir,
-    isTemp
+    isTemp,
+    isFeatured
   );
 
   res

--- a/src/controllers/property.controllers.js
+++ b/src/controllers/property.controllers.js
@@ -87,7 +87,7 @@ propertyControllers.createProperty = asyncWrapper(async (req, res, next) => {
         formatApiResponse(
           201,
           STATUS_TEXT.SUCCESS,
-          "the property created successfully, but the images not found, you can add them by update the blog post",
+          "the property created successfully, but the images not found, you can add them by update the property",
           propertyCreation,
         ),
       );

--- a/src/integrations/image.service.js
+++ b/src/integrations/image.service.js
@@ -11,12 +11,13 @@ const appError = new AppError();
 const imageServices = module.exports;
 
 /**
- *
- * @param {File} file
- * @param {ObjectId} ownerId
- * @param {enum} ownerModel
- * @param {enum} bucketDir
- * @param {boolean} isTemp
+ * @description create image to db and upload it to aws s3 bucket
+ * @param {File} file - the file to be uploaded
+ * @param {ObjectId} ownerId - the owner id of the image
+ * @param {enum} ownerModel - the owner model of the image
+ * @param {enum} bucketDir - default is "default/" if not provided, it is the directory name
+ * @param {boolean} isTemp - default is true, if false then it will be deleted from db and aws s3 bucket on a corn-job
+ * @param {boolean} isFeatured - default is false, if true then it will be the main image
  * @returns
  */
 
@@ -25,7 +26,8 @@ imageServices.createImage = async (
   ownerId,
   ownerModel,
   bucketDir = FILES_CONFIGS.DIRS.DEFAULT,
-  isTemp = true
+  isTemp = true,
+  isFeatured = false
 ) => {
   try {
     if (!file) {
@@ -85,7 +87,7 @@ imageServices.createImage = async (
         width: dimensions?.width,
         height: dimensions?.height,
       },
-      isFeatured: false,
+      isFeatured,
       isTemp,
     };
 

--- a/src/routes/image.routes.js
+++ b/src/routes/image.routes.js
@@ -10,7 +10,7 @@ const authorizedRole = require("../middlewares/authorizedRole");
 const validationErrorHandlerMiddleware = require("../middlewares/validationErrorHandler.middleware");
 const {
   imageTempIdValidation,
-  imageOwnerIdImageValidation,
+  ownerImageValidation,
 } = require("../validations/image.validation");
 
 router.route("/").get(controllers.getImages);
@@ -67,7 +67,7 @@ router
     verifyToken,
     authorizedRole(USER_ROLES.ADMIN, USER_ROLES.MANAGER),
     upload.single("file"),
-    imageOwnerIdImageValidation("propertyId", Property),
+    ownerImageValidation("propertyId", Property),
     validationErrorHandlerMiddleware,
     controllers.createPropertyImage,
   );
@@ -90,7 +90,7 @@ router
     verifyToken,
     authorizedRole(USER_ROLES.ADMIN, USER_ROLES.MANAGER, USER_ROLES.CONTENT),
     upload.single("file"),
-    imageOwnerIdImageValidation("blogPostId", BlogPost),
+    ownerImageValidation("blogPostId", BlogPost),
     validationErrorHandlerMiddleware,
     controllers.createBlogPostImage,
   );

--- a/src/validations/image.validation.js
+++ b/src/validations/image.validation.js
@@ -10,7 +10,11 @@ imageValidation.imageTempIdValidation = () => {
       .withMessage(`${"tempId"} must be a valid mongoId`),
   ];
 };
-imageValidation.imageOwnerIdImageValidation = (field, ownerModel) => {
+imageValidation.ownerImageValidation = (
+  field,
+  ownerModel,
+  isFeatured = false
+) => {
   return [
     body(field)
       .trim()
@@ -20,5 +24,9 @@ imageValidation.imageOwnerIdImageValidation = (field, ownerModel) => {
       .withMessage(`${field} must be a valid mongoId`)
       .custom(async (value) => documentExists("_id", value, ownerModel, false))
       .withMessage(`${field} does not exist`),
+    body("isFeatured")
+      .optional()
+      .isBoolean()
+      .withMessage(`${"isFeatured"} must be a boolean`),
   ];
 };


### PR DESCRIPTION
close #8 

**main fix:**
- enable `sFeatured` body request to create property and blog-post image 
- validate the `isFeatured` body request
- add the value to `imageServices.createImage` service and JSDoc
- default value `isFeatured: true`

**extra changes:**
- refactor `createProperty` controller response msg
- rename `imageOwnerIdImageValidation` -> `ownerImageValidation` validation middleware